### PR TITLE
replace sockWrite with sendMessage

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45,7 +45,7 @@ var BladeReload = /** @class */ (function () {
         var _this = this;
         if (!this.enabled)
             return;
-        chokidar_1.watch(this.options.path, {
+        (0, chokidar_1.watch)(this.options.path, {
             ignoreInitial: true
         }).on('all', function (event, path) {
             _this.log('[' + event + '] ' + path);
@@ -86,7 +86,7 @@ var BladeReload = /** @class */ (function () {
      */
     BladeReload.prototype.reload = function () {
         if (typeof this.serverHandler !== 'undefined') {
-            this.serverHandler.sockWrite(this.serverHandler.sockets, 'content-changed');
+            this.serverHandler.sendMessage(this.serverHandler.webSocketServer.clients, 'content-changed');
         }
     };
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-mix-blade-reload",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Laravel Mix extension to auto-reload browser when you change the blade views.",
   "main": "dist/index.js",
   "files": [
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/krehak/laravel-mix-blade-reload",
   "peerDependencies": {
-    "laravel-mix": "^6.0"
+    "laravel-mix": "^6.0.22"
   },
   "dependencies": {
     "chokidar": "^3.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export class BladeReload {
      */
     private reload(): void {
         if(typeof this.serverHandler !== 'undefined') {
-            this.serverHandler.sendMessage(this.serverHandler.sockets, 'content-changed');
+            this.serverHandler.sendMessage(this.serverHandler.webSocketServer.clients, 'content-changed');
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export class BladeReload {
      */
     private reload(): void {
         if(typeof this.serverHandler !== 'undefined') {
-            this.serverHandler.sockWrite(this.serverHandler.sockets, 'content-changed');
+            this.serverHandler.sendMessage(this.serverHandler.sockets, 'content-changed');
         }
     }
 


### PR DESCRIPTION
`webpack-dev-server@v4` [replaced `sockWrite` with `sendMessage`](https://github.com/webpack/webpack-dev-server/blob/0002ebfbc8f36e92f91013372c9e2bca97022825/migration-v4.md)

I’ve included `laravel-mix@6.0.22` as peerDependency, as that version bumped `webpack-dev-server` from v3 to v4.
This change fixes https://github.com/krehak/laravel-mix-blade-reload/issues/3